### PR TITLE
feat: update openapi generator version to 7.4.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
     id 'org.springframework.boot' version '3.2.2'
     id 'io.spring.dependency-management' version '1.1.3'
 
-    id 'org.openapi.generator' version '5.3.0'
+    id 'org.openapi.generator' version '7.4.0'
 
     id 'jacoco'
 


### PR DESCRIPTION
Upgrade [Openapi generator gradle plugin](https://plugins.gradle.org/plugin/org.openapi.generator) 5.3.0 -> 7.4.0

[Openapi generator CHANGELOG](https://github.com/OpenAPITools/openapi-generator/releases)

This v7.4.0 will allow us to use axios version 1.6.1 instead of 0.21.4 to avoid certain security and implementation problems as specified in the [axios change log](https://github.com/axios/axios/blob/v1.x/CHANGELOG.md).